### PR TITLE
Emit correct links to issues and PRs in the changelog

### DIFF
--- a/niv-updater
+++ b/niv-updater
@@ -258,7 +258,7 @@ createPullRequestsOnUpdate() {
             {
                 printf "## Changelog for %s:\n" "$dep"
                 printf "Commits: [$dep_owner/$dep_repo@%.8s...%.8s](https://github.com/$dep_owner/$dep_repo/compare/${revision}...${new_revision})\n\n" "$revision" "$new_revision"
-                { hub api "/repos/$dep_owner/$dep_repo/compare/${revision}...${new_revision}" || true; } | jq -r '.commits[] | "* [\(.sha[0:8])](\(.html_url)) \(.commit.message | split("\n") | first)"'
+                { hub api "/repos/$dep_owner/$dep_repo/compare/${revision}...${new_revision}" || true; } | jq -r '.commits[] | "* [\(.sha[0:8])](\(.html_url)) \(.commit.message | split("\n") | first)"' | sed "s~\(#[0-9]\+\)~$dep_owner/$dep_repo\1~g"
             } >>"$message"
         fi
 


### PR DESCRIPTION
GitHub used #123 as a shorthand for a URL to the issue **in the same
repository**. Thus, when constructing the changelogs, all #123 in the changelog
would render as a link to the repository where niv-updater-action operates,
instead of pointing to the depdendency's repository.

To fix this issue, prepend anything that looks like #<numbers> with the name of
the dependency (owner/repository).

Closes #8.