### PR TITLE
Add an option to skip showing merges in the changelogs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -50,6 +50,8 @@ jobs:
           labels: |
             documentation
             good first issue
+          # Let's not show merges in the changelog
+          show_merges: false
 ----
 
 == Configuration
@@ -84,6 +86,9 @@ jobs:
   created PRs. Defaults to an empty string, meaning no labels will be applied.
   The list has to be newline separated (use YAML's `|` block), as GitHub allows
   various characters in the label's name, except the newline.
+* `show_merges`: (Optional, a boolean) If `true`, the changelog will contain
+  merge commits listed. Otherwise, they will be skipped (however, the commits
+  from the PRs/branches will shown). Defaults to `false`.
 
 == Secrets
 

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,11 @@ inputs:
     description: 'A list of labels, *newline* separated, that will be applied to the generated PR. Defaults to an empty list.'
     required: false
     default: ''
+  show_merges:
+    description: 'If `true`, the changelog will contain merge commits listed. Otherwise, they will be skipped (however, the commits from the PRs/branches will shown). Defaults to `false`.'
+    required: false
+    default: false
+
 branding:
   # maybe 'refresh-cw'
   icon: 'git-pull-request'

--- a/niv-updater
+++ b/niv-updater
@@ -118,6 +118,12 @@ createPullRequestsOnUpdate() {
 
     echo "Will use branch '$INPUT_PULL_REQUEST_BASE' (ref: $base) as the base branch"
 
+    merges_filter=""
+    if [[ $INPUT_SHOW_MERGES == "false" ]]; then
+        # a filter for jq, to be used in the query for getting the changelog
+        merges_filter="| select((.parents | length) < 2)"
+    fi
+
     SOURCES_JSON='nix/sources.json'
 
     echo "Getting $SOURCES_JSON from $GITHUB_REPOSITORY (ref: $base)"
@@ -258,7 +264,7 @@ createPullRequestsOnUpdate() {
             {
                 printf "## Changelog for %s:\n" "$dep"
                 printf "Commits: [$dep_owner/$dep_repo@%.8s...%.8s](https://github.com/$dep_owner/$dep_repo/compare/${revision}...${new_revision})\n\n" "$revision" "$new_revision"
-                { hub api "/repos/$dep_owner/$dep_repo/compare/${revision}...${new_revision}" || true; } | jq -r '.commits[] | "* [\(.sha[0:8])](\(.html_url)) \(.commit.message | split("\n") | first)"' | sed "s~\(#[0-9]\+\)~$dep_owner/$dep_repo\1~g"
+                { hub api "/repos/$dep_owner/$dep_repo/compare/${revision}...${new_revision}" || true; } | jq -r '.commits[] '"$merges_filter"' | "* [\(.sha[0:8])](\(.html_url)) \(.commit.message | split("\n") | first)"' | sed "s~\(#[0-9]\+\)~$dep_owner/$dep_repo\1~g"
             } >>"$message"
         fi
 


### PR DESCRIPTION
Most of the time these merge commit carry no information. Add the option to skip
them, and make it a sane default.

Closes #6.