### PR TITLE
Allow custom prefix/suffix for commit descriptions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -54,6 +54,13 @@ jobs:
             good first issue
           # Let's not show merges in the changelog
           show_merges: false
+          # Have some prefix and a suffix. Use '|' to keep newlines
+          message_prefix: |
+            ## Motivation
+
+            Dependencies should be up to date.
+          message_suffix:
+            Notify @myorg/myteam.
 ----
 
 == Configuration
@@ -96,6 +103,10 @@ jobs:
 * `show_merges`: (Optional, a boolean) If `true`, the changelog will contain
   merge commits listed. Otherwise, they will be skipped (however, the commits
   from the PRs/branches will shown). Defaults to `false`.
+* `message_prefix`: (Optional) The text that will be put in front of the
+  generated changelog. Defaults to empty.
+* `message_suffix`: (Optional) The text that will be put in after the generated
+  changelog. Defaults to empty.
 
 == Secrets
 

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,14 @@ inputs:
     description: 'If `true`, the changelog will contain merge commits listed. Otherwise, they will be skipped (however, the commits from the PRs/branches will shown). Defaults to `false`.'
     required: false
     default: false
+  message_prefix:
+    description: 'The text that will be put in front of the generated changelog. Defaults to empty.'
+    required: false
+    default: ''
+  message_suffix:
+    description: 'The text that will be put in after the generated changelog. Defaults to empty.'
+    required: false
+    default: ''
 
 branding:
   # maybe 'refresh-cw'

--- a/niv-updater
+++ b/niv-updater
@@ -253,6 +253,10 @@ createPullRequestsOnUpdate() {
         printf "Will generate the Pull Request message for '$dep', update from %.8s to %.8s\n" "$revision" "$new_revision"
 
         printf "niv %s: update %.8s -> %.8s" "$dep" "$revision" "$new_revision" >>"$title"
+
+        # print with a new line appended, as yaml swallows those
+        printf "%s%s" "$INPUT_MESSAGE_PREFIX" "${INPUT_MESSAGE_PREFIX:+$'\n'}" >>"$message"
+
         # get a short changelog if we're on github
         if [[ -z $is_github ]]; then
             # pretty sure this is not github
@@ -266,6 +270,9 @@ createPullRequestsOnUpdate() {
                 { hub api "/repos/$dep_owner/$dep_repo/compare/${revision}...${new_revision}" || true; } | jq -r '.commits[] '"$merges_filter"' | "* [`\(.sha[0:8])`](\(.html_url)) \(.commit.message | split("\n") | first)"' | sed "s~\(#[0-9]\+\)~$dep_owner/$dep_repo\1~g"
             } >>"$message"
         fi
+
+        # print with a new line appended, as yaml swallows those
+        printf "%s%s" "$INPUT_MESSAGE_SUFFIX" "${INPUT_MESSAGE_SUFFIX:+$'\n'}" >>"$message"
 
         # create the branch
         echo "Creating branch '$branch_name' for the update of '$dep'"


### PR DESCRIPTION
Hopefully, this will be helpful for someone.

Closes #7.