### PR TITLE
Fix generated commit message

### DIFF
--- a/niv-updater
+++ b/niv-updater
@@ -293,9 +293,15 @@ createPullRequestsOnUpdate() {
         # upload the content
         echo "Uploading the new $SOURCES_JSON"
         new_content=$(mktemp)
+        commit_message=$(mktemp)
+        {
+            cat "$title"
+            printf "\n"
+            cat "$message"
+        } >"$commit_message"
         base64 "$wdir/$SOURCES_JSON" >>"$new_content"
         if ! hub api -XPUT \
-            -F message=@"$message" \
+            -F message=@"$commit_message" \
             -F content=@"$new_content" \
             -F sha="$file_sha" \
             -F branch="$branch_name" \
@@ -325,6 +331,7 @@ createPullRequestsOnUpdate() {
         rm -rf "$wdir"
         rm -f "$pr_data"
         rm -f "$new_content"
+        rm -f "$commit_message"
         rm -f "$message"
         rm -f "$title"
 


### PR DESCRIPTION
git commit messages start with the subject, followed by an empty line and the body
of the commit. Due to old refactoring, the generated commit messages lost the
subject line, as that was now in the title, that is a separate file, used to set
the title of the PR. This change stores the commit message in a separate file
and generates it following the convention.

Closes #16 