### PR TITLE
Check GITHUB_TOKEN

### DIFF
--- a/niv-updater
+++ b/niv-updater
@@ -8,6 +8,13 @@ error() {
     exit 1
 }
 
+# Check if GITHUB_TOKEN is correct (maybe due to misconfiguration, we might get an expired one)
+checkCredentials() {
+    if ! curl --fail -s -H "Authorization: token $GITHUB_TOKEN" 'https://api.github.com/'; then
+        error "GITHUB_TOKEN is incorrect, aborting"
+    fi
+}
+
 # Install all the dependencies we need, using Nix
 setupPrerequisites() {
     echo "Installing Nix"
@@ -327,6 +334,7 @@ createPullRequestsOnUpdate() {
     echo "Checking for updates - done"
 }
 
+checkCredentials
 setupPrerequisites
 setupNetrc
 sanitizeInputs


### PR DESCRIPTION
Fail early in case the action receives a wrong GITHUB_TOKEN, that is, one that
is invalid. This doesn't cover the case where the token doesn't have sufficient
rights, as that will be discovered later.

Closes #15