### PR TITLE
Add a title prefix support

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -61,7 +61,7 @@ jobs:
             Dependencies should be up to date.
           message_suffix:
             Notify @myorg/myteam.
-          # Have a prefix to the commit title itself, for supporting conventional commits.
+          # Have a prefix to the commit title itself, for example, to support conventional commits.
           title_prefix: refactor:
 ----
 
@@ -118,4 +118,3 @@ Secrets are similar to inputs except that they are encrypted and only used by Gi
 
 * `GITHUB_TOKEN` - (Required) The GitHub API token used to create pull requests
   and get content from all repositories tracked by `niv`.
-

--- a/README.adoc
+++ b/README.adoc
@@ -61,6 +61,8 @@ jobs:
             Dependencies should be up to date.
           message_suffix:
             Notify @myorg/myteam.
+          # Have a prefix to the commit title itself, for supporting conventional commits.
+          title_prefix: refactor:
 ----
 
 == Configuration
@@ -107,6 +109,8 @@ jobs:
   generated changelog. Defaults to empty.
 * `message_suffix`: (Optional) The text that will be put in after the generated
   changelog. Defaults to empty.
+* `title_prefix`: (Optional) The text that will be put in front of the
+  generated commit title. Defaults to empty.
 
 == Secrets
 

--- a/action.yml
+++ b/action.yml
@@ -45,6 +45,10 @@ inputs:
     description: 'The text that will be put in after the generated changelog. Defaults to empty.'
     required: false
     default: ''
+  title_prefix:
+    description: 'The text that will be put in front of the generated commit title. Defaults to empty.'
+    required: false
+    default: ''
 
 branding:
   # maybe 'refresh-cw'

--- a/niv-updater
+++ b/niv-updater
@@ -259,7 +259,7 @@ createPullRequestsOnUpdate() {
 
         printf "Will generate the Pull Request message for '$dep', update from %.8s to %.8s\n" "$revision" "$new_revision"
 
-        printf "niv %s: update %.8s -> %.8s" "$dep" "$revision" "$new_revision" >>"$title"
+        printf "%s niv %s: update %.8s -> %.8s" "$INPUT_TITLE_PREFIX" "$dep" "$revision" "$new_revision" >>"$title"
 
         # print with a new line appended, as yaml swallows those
         printf "%s%s" "$INPUT_MESSAGE_PREFIX" "${INPUT_MESSAGE_PREFIX:+$'\n'}" >>"$message"


### PR DESCRIPTION
Have a prefix to the commit title itself, for example, to support conventional commits.