### PR TITLE
Do not install hub and jo via Nix

### DIFF
--- a/niv-updater
+++ b/niv-updater
@@ -36,9 +36,9 @@ setupPrerequisites() {
     # shellcheck disable=SC1090
     source "${HOME}/.nix-profile/etc/profile.d/nix.sh"
 
-    # we also need jq and git, but they both come with ubuntu-latest with GitHub Actions
+    # we also need jq, hub, and git, but they both come with ubuntu-latest with GitHub Actions
     # https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md
-    nix-env -iA nixpkgs.gitAndTools.hub nixpkgs.jo
+    nix-env -iA nixpkgs.jo
     nix-env -iA niv -f https://github.com/nmattia/niv/tarball/master \
         --substituters https://niv.cachix.org \
         --trusted-public-keys niv.cachix.org-1:X32PCg2e/zAm3/uD1ScqW2z/K0LtDyNV7RdaxIuLgQM=

--- a/niv-updater
+++ b/niv-updater
@@ -38,7 +38,6 @@ setupPrerequisites() {
 
     # we also need jq, hub, and git, but they both come with ubuntu-latest with GitHub Actions
     # https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md
-    nix-env -iA nixpkgs.jo
     nix-env -iA niv -f https://github.com/nmattia/niv/tarball/master \
         --substituters https://niv.cachix.org \
         --trusted-public-keys niv.cachix.org-1:X32PCg2e/zAm3/uD1ScqW2z/K0LtDyNV7RdaxIuLgQM=
@@ -102,11 +101,7 @@ applyLabels() {
         return
     fi
 
-    local labels
-    mapfile -t labels < <(printf "%s" "$INPUT_LABELS")
-    payload=$(jo labels="$(jo -a "${labels[@]}")")
-
-    if ! printf "%s" "$payload" | hub api -XPOST --input - \
+    if ! jq -n --arg labs "$INPUT_LABELS" '{labels: $labs | split("\n") }' | hub api -XPOST --input - \
         "/repos/$GITHUB_REPOSITORY/issues/$pr_number/labels" >/dev/null; then
         echo "::warning::could not assign labels to the PR $pr_number"
     fi


### PR DESCRIPTION
This will speed up the execution a bit.

- `hub` is provided by the base image
- `jo`'s use has been replaced by `jq` -- `jq` is already used pervasively.