### PR TITLE
Notify owners on new issue creation

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,6 @@
+---
+name: Default Issue Template
+title: ''
+labels: "@project/notify-owners"
+assignees: knl
+---

--- a/.github/workflows/issue-notifier.yml
+++ b/.github/workflows/issue-notifier.yml
@@ -1,0 +1,8 @@
+uses: timheuer/issue-notifier@v1.0.2
+env:
+  SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
+with:
+  fromMailAddress: 'nikola+sendgrid@knezevic.ch'
+  toMailAddress: 'github@nikola.knezevic.ch'
+  subject: 'A new issue was labeled/created in niv-updater-action'
+  labelsToMonitor: '@project/notify-owners'


### PR DESCRIPTION
Since GitHub doesn't have a good system for such a critical feature, make one.

This relies on two features:
- issue template will assign a label and make me the assignee for the issue
- if the latter doesn't cause a notification by email, the label will trigger issue-notifier action to send me an email via sendgrid

I really hate when I open an issue and I don't hear back. I don't want others to suffer with the same in my repositories.