### PR TITLE
Fix whitespace/newline issues

### DIFF
--- a/niv-updater
+++ b/niv-updater
@@ -254,7 +254,7 @@ createPullRequestsOnUpdate() {
 
         printf "Will generate the Pull Request message for '$dep', update from %.8s to %.8s\n" "$revision" "$new_revision"
 
-        printf "%s niv %s: update %.8s -> %.8s" "$INPUT_TITLE_PREFIX" "$dep" "$revision" "$new_revision" >>"$title"
+        printf "%sniv %s: update %.8s -> %.8s" "$INPUT_TITLE_PREFIX${INPUT_TITLE_PREFIX:+ }" "$dep" "$revision" "$new_revision" >>"$title"
 
         # print with a new line appended, as yaml swallows those
         printf "%s%s" "$INPUT_MESSAGE_PREFIX" "${INPUT_MESSAGE_PREFIX:+$'\n'}" >>"$message"

--- a/niv-updater
+++ b/niv-updater
@@ -293,7 +293,7 @@ createPullRequestsOnUpdate() {
         commit_message=$(mktemp)
         {
             cat "$title"
-            printf "\n"
+            printf '\n\n'
             cat "$message"
         } >"$commit_message"
         base64 "$wdir/$SOURCES_JSON" >>"$new_content"


### PR DESCRIPTION
Fix improperly created commit message (an empty line was not present between the title and the body).

Remove an empty space at the beginning of the title, when no title prefix is provided.