### PR TITLE
Rename ref attribute to branch

### DIFF
--- a/niv-updater
+++ b/niv-updater
@@ -248,7 +248,7 @@ createPullRequestsOnUpdate() {
             # rewrite the entry so that we can use token instead of SSH
             if [[ -n $github_ssh ]]; then
                 echo 'As this is a dependency fetched with SSH, trying to switch to https type'
-                niv_branch="$(jq -r ".\"$dep\".ref // empty" <"$wdir/$SOURCES_JSON")"
+                niv_branch="$(jq -r ".\"$dep\".branch // empty" <"$wdir/$SOURCES_JSON")"
                 niv drop "$dep"
                 niv add "$dep_owner/$dep_repo" -a rev="$revision" -a branch="$niv_branch"
                 rm "$SOURCES_JSON.orig"
@@ -310,7 +310,7 @@ createPullRequestsOnUpdate() {
             echo "Dependency '$dep' is hosted on github.com"
 
             {
-                niv_branch="$(jq -r ".\"$dep\".ref // empty" <"$wdir/$SOURCES_JSON")"
+                niv_branch="$(jq -r ".\"$dep\".branch // empty" <"$wdir/$SOURCES_JSON")"
                 printf '## Changelog for %s:\n' "$dep"
                 printf 'Branch: %s\n' "$niv_branch"
                 printf 'Commits: [%s/%s@%.8s...%.8s](https://github.com/%s/%s/compare/%s...%s)\n\n' "$dep_owner" "$dep_repo" "$revision" "$new_revision" "$dep_owner" "$dep_repo" "$revision" "$new_revision"


### PR DESCRIPTION
Recent [changes in niv](https://github.com/nmattia/niv/pull/268) dropped
the usage of `ref` as a branch in git sources. The new attribute name is
`branch`.