### PR TITLE
Make niv version configurable

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -43,6 +43,8 @@ jobs:
           pull_request_base: ''
           # The path in the repo to the sources.json file
           sources_file: 'nix/sources.json'
+          # The niv version to use. `master` will track the latest niv.
+          niv_version: 'master'
           # The prefix to add to every created branch
           branch_prefix: 'update/'
           # If there are revisions in form 'v1.2' (not SHAs), skip updating them
@@ -83,6 +85,9 @@ jobs:
 * `sources_file`: (Optional) The path in the repo to the `sources.json` file.
   This value will be passed to niv via `--sources-file` option. Defaults to
   `nix/sources.json`.
+* `niv_version`: (Optional) The niv version to be used. Defaults to `master`,
+  meaning niv-updater-action will take the latest niv for each run. You may want
+  to fix a particular version and avoid future breaks to your workflow.
 * `branch_prefix`: (Optional) The prefix used for update branches, created by
   this action. The action does not sanitize the branch name. For a description
   of what a valid branch name is, please consult:

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'The path in the repo to the sources.json file. This value will be passed to niv via `--sources-file` option. Defaults to `nix/sources.json`.'
     required: false
     default: 'nix/sources.json'
+  niv_version:
+    description: 'The niv version to be used. Defaults to `master`, meaning niv-updater-action will take the latest niv for each run. You may want to fix a particular version and avoid future breaks to your workflow.'
+    required: false
+    default: 'master'
   branch_prefix:
     description: 'The prefix used for update branches, created by this action. The action does not sanitize the branch name. For a description of what a valid branch name is, please consult: https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-check-ref-format.html. Defaults to "update/".'
     required: false

--- a/niv-updater
+++ b/niv-updater
@@ -38,7 +38,7 @@ setupPrerequisites() {
 
     # we also need jq, hub, and git, but they both come with ubuntu-latest with GitHub Actions
     # https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md
-    nix-env -iA niv -f https://github.com/nmattia/niv/tarball/master \
+    nix-env -iA niv -f "https://github.com/nmattia/niv/tarball/$INPUT_NIV_VERSION" \
         --substituters https://niv.cachix.org \
         --trusted-public-keys niv.cachix.org-1:X32PCg2e/zAm3/uD1ScqW2z/K0LtDyNV7RdaxIuLgQM=
     echo 'Installing dependencies - done'


### PR DESCRIPTION
This avoids problems where newer versions of niv may break workflows,
due to backwards incompatible changes, or just bugs.

By default, we track master, which was the current behavior. However,
one may want to pin to a particular version of niv, because niv+Nix are
all about pinning.

Closes #4 