### PR TITLE
Add option for debug logs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -70,6 +70,8 @@ jobs:
             Notify @myorg/myteam.
           # Have a prefix to the commit title itself, for example, to support conventional commits.
           title_prefix: refactor:
+          # Do not output lines as they are executed (`set -x`)
+          debug_output: false
 ----
 
 == Configuration
@@ -130,6 +132,10 @@ jobs:
   issues. For more details, see
   https://github.com/knl/niv-updater-action/issues/26[Issue #26]. Defaults to
   `true`.
+* `debug_output`: (Optional, a boolean) If `true`, `set -x` will be turned on
+  for the updater script, outputing every step the action takes. This will show
+  up in the action log, and could be useful for trying to reproduce issues
+  locally. Defaults to `false`.
 
 == Secrets
 

--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,10 @@ inputs:
     description: 'If `true`, the changelog will transform all issue links to links via a redirector, to prevent GitHub from backreferencing the created PR in these issues. Defaults to `true`.'
     required: false
     default: true
+  debug_output:
+    description: If `true`, `set -x` will be turned on for the updater script, outputing every step the action takes. This will show up in the action log, and could be useful for trying to reproduce issues locally. Defaults to `false`.
+    required: false
+    default: false
 
 branding:
   # maybe 'refresh-cw'

--- a/niv-updater
+++ b/niv-updater
@@ -385,6 +385,10 @@ createPullRequestsOnUpdate() {
     echo 'Checking for updates - done'
 }
 
+if [[ $INPUT_DEBUG_OUTPUT == 'true' ]]; then
+    set -x
+fi
+
 checkCredentials
 setupPrerequisites
 setupNetrc


### PR DESCRIPTION
Enabling `debug_output` will run the updater script under `set -x`,
effectively printing out any command that is to be executed. This can
help with reproducing the issues locally or plain old debugging.

Closes #34.