### PR TITLE
Fix commit message when PRs are updated

### DIFF
--- a/niv-updater
+++ b/niv-updater
@@ -446,7 +446,7 @@ createPullRequestsOnUpdate() {
                 if ! jq -ncj \
                     --arg parent "$base" \
                     --arg tree "$(jq -jr '.sha' <"$tree_data")" \
-                    --rawfile message "$message" \
+                    --rawfile message "$commit_message" \
                     '{message: $message, tree: $tree, parents: [$parent]}' \
                     | hub api -XPOST \
                         --input - \


### PR DESCRIPTION
When updating PRs, the code was taking just the commit message for the
new commit, instead of the combined title + message. This change fixes
it.