### PR TITLE
Handle pull base other than master

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   pull_request_base:
     description: 'The name of the branch to issue the pull requests against. Defaults to an empty string, which means to take the default branch for the repository.'
     required: false
-    default: 'master'
+    default: ''
   sources_file:
     description: 'The path in the repo to the sources.json file. This value will be passed to niv via `--sources-file` option. Defaults to `nix/sources.json`.'
     required: false

--- a/niv-updater
+++ b/niv-updater
@@ -164,7 +164,13 @@ createPullRequestsOnUpdate() {
         base="$GITHUB_SHA"
     else
         # get the SHA of the current base, so that it remains fixed during the run
-        base="$(hub api "/repos/$GITHUB_REPOSITORY/branches/$INPUT_PULL_REQUEST_BASE" | jq -jr '.commit.sha')"
+        # This can fail if the branch doesn't exist. jq would return nothing in that case.
+        set +euo pipefail
+        base="$(hub api "/repos/$GITHUB_REPOSITORY/branches/$INPUT_PULL_REQUEST_BASE" | jq -jr '.commit.sha // empty')"
+        if [[ -z $base ]]; then
+            error "Could not get the SHA for branch '$INPUT_PULL_REQUEST_BASE'"
+        fi
+        set -euo pipefail
     fi
 
     echo "Will use branch '$INPUT_PULL_REQUEST_BASE' (ref: $base) as the base branch"


### PR DESCRIPTION
Since GitHub switched to using `main` as the main branch (it used to be
`master`), update this action to support such case.

Also, in case there is a problem getting SHA for the branch, report an error
instead of silently dying.