### PR TITLE
Use cache.nixos.org

### DIFF
--- a/niv-updater
+++ b/niv-updater
@@ -42,9 +42,11 @@ setupPrerequisites() {
 
     # we also need hub, and git, but they both come with ubuntu-latest with GitHub Actions
     # https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md
+    # NOTE: We add 'cache.nixos.org' as a substituer because niv uses it as an upstream cache:
+    # https://blog.cachix.org/posts/2020-07-28-upstream-caches-avoiding-pushing-paths-in-cache-nixos-org/
     nix-env -iA niv -f "https://github.com/nmattia/niv/tarball/$INPUT_NIV_VERSION" \
-        --substituters https://niv.cachix.org \
-        --trusted-public-keys niv.cachix.org-1:X32PCg2e/zAm3/uD1ScqW2z/K0LtDyNV7RdaxIuLgQM=
+        --substituters 'https://niv.cachix.org https://cache.nixos.org' \
+        --trusted-public-keys 'niv.cachix.org-1:X32PCg2e/zAm3/uD1ScqW2z/K0LtDyNV7RdaxIuLgQM= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY='
     # We need --rawfile for jq, available in jq 1.6, which is only available on ubuntu 20.04 and macos
     nix-env -iA nixpkgs.jq
     echo 'Installing dependencies - done'

--- a/niv-updater
+++ b/niv-updater
@@ -42,7 +42,7 @@ setupPrerequisites() {
 
     # we also need hub, and git, but they both come with ubuntu-latest with GitHub Actions
     # https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md
-    # NOTE: We add 'cache.nixos.org' as a substituer because niv uses it as an upstream cache:
+    # NOTE: We add 'cache.nixos.org' as a substituter because niv uses it as an upstream cache:
     # https://blog.cachix.org/posts/2020-07-28-upstream-caches-avoiding-pushing-paths-in-cache-nixos-org/
     nix-env -iA niv -f "https://github.com/nmattia/niv/tarball/$INPUT_NIV_VERSION" \
         --substituters 'https://niv.cachix.org https://cache.nixos.org' \


### PR DESCRIPTION
Closes #45 

This ensures that we pull dependencies from niv's upstream cache as well, `cache.nixos.org`. Otherwise the action may spend hours rebuilding niv (ok, not niv itself, but dependencies).

NOTE: would be good to suggest to users that they set a [`timeout-minutes`](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes) of O(1minute) to avoid hours of actions time being wasted rebuilding the world!

NOTE2: unfortunately we can't set `--max-jobs` to 0 because `nix-env` is trying to build something (most likely the user profile). I guess you could do a `nix-build --max-jobs 0` followed by a `nix-env -i --max-jobs <non-zero>`.

NOTE3: actually why not simply adding the output of `nix-build` to the `PATH` instead of installing it?