### PR TITLE
Bump `nix` to 2.11.1

### DIFF
--- a/niv-updater
+++ b/niv-updater
@@ -30,7 +30,7 @@ setupPrerequisites() {
         sudo sh -c 'echo "http2 = false" >> /etc/nix/nix.conf'
 
         # pin to ensure future upgrades do not interfere with the subsequent steps
-        sh <(curl -sSL https://releases.nixos.org/nix/nix-2.3.16/install) --no-daemon
+        sh <(curl -sSL https://releases.nixos.org/nix/nix-2.11.1/install) --no-daemon
     fi
 
     echo 'Installing Nix - done'


### PR DESCRIPTION
This might actually fail (depending on which commands you use) because starting with 2.4 the two-word commands became guarded by an option. So this should be tested before releasing :-)