### PR TITLE
Enable action using self hosted runners

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -169,7 +169,7 @@ Actions workflow YAML file.
 == Self hosted runner
 
 Self-hosted runners are running with dynamic users so nix profile is not accessible, as well as nix-env.
-As this action relies on nix-env to install niv,the default configuration will not work. Thus, to use niv from
+As this action relies on nix-env to install niv, the default configuration will not work. Thus, to use niv from
 available nixpkgs, set `niv_version` to `*from-nixpkgs*`. It will install `niv` using `nixpkgs` with nix-shell
 instead of nix-env.
 

--- a/README.adoc
+++ b/README.adoc
@@ -168,9 +168,12 @@ Actions workflow YAML file.
 
 == Self hosted runner
 
-To run this action with a self hosted runner you will need the input `niv_version` declared 
-with `nixpkgs`. It will install `niv` using `nixpkgs` with nix-shell instead of nix-env.
-To avoid using `sudo`, the input `skip_ssh_repos` should be set to `true`.
+Self-hosted runners are running with dynamic users so nix profile is not accessible, as well as nix-env.
+As this action relies on nix-env to install niv,the default configuration will not work. Thus, to use niv from
+available nixpkgs, set `niv_version` to `*from-nixpkgs*`. It will install `niv` using `nixpkgs` with nix-shell
+instead of nix-env.
+
+To avoid using `sudo` (also unavailable on self-hosted runners), the input `skip_ssh_repos` should be set to `true`.
 
 Example:
 

--- a/README.adoc
+++ b/README.adoc
@@ -165,3 +165,32 @@ Actions workflow YAML file.
 
 * `GITHUB_TOKEN` - (Required) The GitHub API token used to create pull requests
   and get content from all repositories tracked by `niv`.
+
+== Self hosted runner
+
+To run this action with a self hosted runner you will need the input `niv_version` declared 
+with `nixpkgs`. It will install `niv` using `nixpkgs` with nix-shell instead of nix-env.
+To avoid using `sudo`, the input `skip_ssh_repos` should be set to `true`.
+
+Example:
+
+[source,yaml]
+----
+name: Automated niv-managed dependency updates
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # run this every day at 4:00am
+    - cron:  '0 4 * * *'
+jobs:
+  niv-updater:
+    name: 'Create PRs for niv-managed dependencies'
+    runs-on: ubuntu-latest
+    steps:
+      # notice there is no checkout step
+      - name: niv-updater-action
+        uses: knl/niv-updater-action@v10
+	with:
+          niv_version: 'nixpkgs'
+	  skip_ssh_repos: true
+----

--- a/niv-updater
+++ b/niv-updater
@@ -39,18 +39,29 @@ setupPrerequisites() {
     export PATH="${PATH}:/nix/var/nix/profiles/per-user/runner/profile/bin:/nix/var/nix/profiles/default/bin"
 
     # shellcheck disable=SC1091
-    source "${HOME}/.nix-profile/etc/profile.d/nix.sh"
+    test -f "${HOME}/.nix-profile/etc/profile.d/nix.sh" && source "${HOME}/.nix-profile/etc/profile.d/nix.sh"
 
-    # we also need hub, and git, but they both come with ubuntu-latest with GitHub Actions
-    # https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md
-    # NOTE: We add 'cache.nixos.org' as a substituter because niv uses it as an upstream cache:
-    # https://blog.cachix.org/posts/2020-07-28-upstream-caches-avoiding-pushing-paths-in-cache-nixos-org/
-    nix-env -iA niv -f "https://github.com/nmattia/niv/tarball/$INPUT_NIV_VERSION" \
-        --substituters 'https://niv.cachix.org https://cache.nixos.org' \
-        --trusted-public-keys 'niv.cachix.org-1:X32PCg2e/zAm3/uD1ScqW2z/K0LtDyNV7RdaxIuLgQM= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY='
+    PACKAGES=(jq moreutils curl)
+    if [[ $INPUT_NIV_VERSION == 'nixpkgs' ]]; then
+        PACKAGES+=(niv)
+    else
+        # we also need hub, and git, but they both come with ubuntu-latest with GitHub Actions
+        # https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md
+        # NOTE: We add 'cache.nixos.org' as a substituter because niv uses it as an upstream cache:
+        # https://blog.cachix.org/posts/2020-07-28-upstream-caches-avoiding-pushing-paths-in-cache-nixos-org/
+        nix-env -iA niv -f "https://github.com/nmattia/niv/tarball/$INPUT_NIV_VERSION" \
+            --substituters 'https://niv.cachix.org https://cache.nixos.org' \
+            --trusted-public-keys 'niv.cachix.org-1:X32PCg2e/zAm3/uD1ScqW2z/K0LtDyNV7RdaxIuLgQM= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY='
+    fi
     # We need --rawfile for jq, available in jq 1.6, which is only available on ubuntu 20.04 and macos
     # We need moreutils because of the sponge utility (to simplify the code)
-    nix-env -iA nixpkgs.jq nixpkgs.moreutils
+
+    # Install if hub dependency is missing on self hosted runner
+    [[ $(type -P "hub") ]] || PACKAGES+=(hub)
+
+    # shellcheck disable=SC2016
+    PATH="${PATH}:$(nix-shell -I "nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-22.11.tar.gz" -p "${PACKAGES[@]}" --command 'echo $PATH')"
+
     echo 'Installing dependencies - done'
 }
 
@@ -558,8 +569,8 @@ if [[ $INPUT_DEBUG_OUTPUT == 'true' ]]; then
     export HUB_VERBOSE=true
 fi
 
-checkCredentials
 setupPrerequisites
+checkCredentials
 setupNetrc
 sanitizeInputs
 createPullRequestsOnUpdate

--- a/niv-updater
+++ b/niv-updater
@@ -42,7 +42,7 @@ setupPrerequisites() {
     test -f "${HOME}/.nix-profile/etc/profile.d/nix.sh" && source "${HOME}/.nix-profile/etc/profile.d/nix.sh"
 
     PACKAGES=(jq moreutils curl)
-    if [[ $INPUT_NIV_VERSION == 'nixpkgs' ]]; then
+    if [[ $INPUT_NIV_VERSION == "*from-nixpkgs*" ]]; then
         PACKAGES+=(niv)
     else
         # we also need hub, and git, but they both come with ubuntu-latest with GitHub Actions


### PR DESCRIPTION
Self hosted runners are running with dynamic users so nix profile is not
accessible. Use nix-shell to have the required dependencies in PATH instead.
