### PR TITLE
Remove refs/heads/ from the base branch name

### DIFF
--- a/niv-updater
+++ b/niv-updater
@@ -164,6 +164,7 @@ createPullRequestsOnUpdate() {
     echo 'Checking for updates'
     if [[ -z $INPUT_PULL_REQUEST_BASE ]]; then
         INPUT_PULL_REQUEST_BASE="${GITHUB_REF#refs/heads/}"
+        INPUT_PULL_REQUEST_BASE="${INPUT_PULL_REQUEST_BASE#refs/tags/}"
         base="$GITHUB_SHA"
     else
         # get the SHA of the current base, so that it remains fixed during the run

--- a/niv-updater
+++ b/niv-updater
@@ -163,7 +163,7 @@ formatIssueLinks() {
 createPullRequestsOnUpdate() {
     echo 'Checking for updates'
     if [[ -z $INPUT_PULL_REQUEST_BASE ]]; then
-        INPUT_PULL_REQUEST_BASE="$GITHUB_REF"
+        INPUT_PULL_REQUEST_BASE="${GITHUB_REF#refs/heads/}"
         base="$GITHUB_SHA"
     else
         # get the SHA of the current base, so that it remains fixed during the run


### PR DESCRIPTION
Base branch should not include `refs/heads/`