### PR TITLE
Use nodejs 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'niv Updater Action'
 description: 'A GitHub action that detects updates to dependencies tracked by niv and creates pull requests to keep them up to date.'
 author: 'knl'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'main.js'
 inputs:
   pull_request_base:


### PR DESCRIPTION
Node 16 has reached its end of life

More details here: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/